### PR TITLE
Set the output path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ TEST?=$$(go list ./... | grep -v 'vendor')
 HOSTNAME=jsherz
 NAME=node-lambda-packager
 BINARY=terraform-provider-${NAME}
-VERSION=1.1.1
+VERSION=1.2.0
 OS_ARCH=linux_amd64
 
 default: install

--- a/internal/provider/data_source_lambda_package.go
+++ b/internal/provider/data_source_lambda_package.go
@@ -117,6 +117,7 @@ func (d *LambdaPackageDataSource) Schema(ctx context.Context, req datasource.Sch
 			},
 			//nolint:exhaustruct // too many props to be useful
 			"filename": schema.StringAttribute{
+				Optional:    true,
 				Computed:    true,
 				Description: "Path to the packaged lambda zip.",
 			},
@@ -322,10 +323,15 @@ func (d *LambdaPackageDataSource) Read(ctx context.Context, req datasource.ReadR
 	hash := sha256.Sum256(res)
 	encodedHash := base64.StdEncoding.EncodeToString(hash[:])
 
-	finalOutputPath := path.Join(
-		filepath.Dir(entrypointPath),
-		strings.ReplaceAll(filepath.Base(entrypointPath), filepath.Ext(entrypointPath), "")+"-package.zip",
-	)
+	var finalOutputPath string
+	if data.Filename.IsNull() {
+		finalOutputPath = path.Join(
+			filepath.Dir(entrypointPath),
+			strings.ReplaceAll(filepath.Base(entrypointPath), filepath.Ext(entrypointPath), "")+"-package.zip",
+		)
+	} else {
+		finalOutputPath = data.Filename.ValueString()
+	}
 
 	err = os.WriteFile(finalOutputPath, res, currentUserRead)
 	if err != nil {


### PR DESCRIPTION
As mentioned in issue https://github.com/jSherz/terraform-provider-node-lambda-packager/issues/5: `filename` is currently a computed property that stores the path of the output zip, and is placed in the same directory as the `entrypointPath`.

I want to be able to put the zip in a gitignored directory where I store build artifacts.
So `filename` can now be optionally set to the desired path of the output zip directly.

Example:
```terraform
data "node-lambda-packager_package" "this" {
  args = [
    "--bundle",
    "--external:@aws-sdk*",
    "--external:@aws-lambda-powertools*",
    "--minify",
    "--platform=node",
    "--sourcemap",
    "--target=es2021",
    "--sourcemap=inline",
  ]

  entrypoint        = var.entrypoint
  working_directory = var.working_directory
  filename          = "../some-directory/output.zip" # This is new, and optional
}
```
